### PR TITLE
Bump oauth2 to 1.2

### DIFF
--- a/mailchimp3.gemspec
+++ b/mailchimp3.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "excon", "~> 0.45.3"
-  s.add_dependency "oauth2", "~> 1.0.0"
+  s.add_dependency "oauth2", "~> 1.2.0"
   s.add_development_dependency "rspec", "~> 3.2"
   s.add_development_dependency "webmock", "~> 1.21"
   s.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
The oauth2 gem was locked to rack 1.2.x, but we rack 2.x is required
for rails 5.

ref: https://git.io/vXUy2
