### PR TITLE
Add PUT method support

### DIFF
--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -44,6 +44,13 @@ module MailChimp3
       _build_response(@last_result)
     end
 
+    def put(body = {})
+      @last_result = _connection.put(@url) do |req|
+        req.body = body.to_json
+      end
+      _build_response(@last_result)
+    end
+
     def delete
       @last_result = _connection.delete(@url)
       if @last_result.status == 204

--- a/spec/mailchimp3/endpoint_spec.rb
+++ b/spec/mailchimp3/endpoint_spec.rb
@@ -197,6 +197,38 @@ describe MailChimp3::Endpoint do
     end
   end
 
+  describe '#put' do
+    subject { base.lists[list_id].members[md5_hash] }
+
+    let(:list_id) { 'd3ed40bd7c' }
+    let(:member_email) { 'test@email.com' }
+    let(:md5_hash) { Digest::MD5.hexdigest(member_email) }
+    let(:resource) do
+      {
+        'email_address'   => member_email,
+        'status_if_new'   => 'subscribed'
+      }
+    end
+
+    let(:result) do
+      {
+        'id'      => md5_hash,
+        'list_id' => list_id,
+        'status'  => 'subscribed'
+      }
+    end
+
+    before do
+      stub_request(:put, "https://us2.api.mailchimp.com/3.0/lists/#{list_id}/members/#{md5_hash}")
+        .to_return(status: 200, body: result.to_json, headers: { 'Content-Type' => 'application/json; charset=utf-8' })
+      @result = subject.put(resource)
+    end
+
+    it 'returns the result of making a PUT request to the endpoint' do
+      expect(@result).to eq(result)
+    end
+  end
+
   describe '#delete' do
     subject { base.lists['d3ed40bd7c'] }
 
@@ -210,4 +242,5 @@ describe MailChimp3::Endpoint do
       expect(@result).to eq(true)
     end
   end
+
 end


### PR DESCRIPTION
MailChimp API has PUT endpoints, but sending PUT requests wasn't implemented in the wrapper.

Sometime PUT might be extremely useful, eg. in a case when you want to add a member to a list, but don't know if an email is already in: https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash

