### PR TITLE
chore: loosen faraday dependency

### DIFF
--- a/mailchimp3.gemspec
+++ b/mailchimp3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "faraday", "~> 0.9.1"
+  s.add_dependency "faraday", "~> 0.9"
   s.add_dependency "excon", "~> 0.45"
   s.add_dependency "oauth2", "~> 1.2"
   s.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
Versions before 0.11 use `Fixnum`, which is deprecated as of Ruby 2.4.