### PR TITLE
fix: no content response from posts

### DIFF
--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -34,7 +34,11 @@ module MailChimp3
         body[:apikey] = @oauth_access_token || @basic_auth_key if @version == 2
         req.body = body.to_json
       end
-      _build_response(@last_result)
+      if @last_result.status == 204
+        true
+      else
+        _build_response(@last_result)
+      end
     end
 
     def patch(body = {})

--- a/spec/mailchimp3/endpoint_spec.rb
+++ b/spec/mailchimp3/endpoint_spec.rb
@@ -167,6 +167,17 @@ describe MailChimp3::Endpoint do
         end
       end
     end
+
+    context 'when the response is 204' do
+      before do
+        stub_request(:post, 'https://us2.api.mailchimp.com/3.0/lists')
+          .to_return(status: 204, body: nil, headers: { 'Content-Type' => 'application/json; charset=utf-8' })
+      end
+
+      it 'returns true' do
+        expect(subject.post(resource)).to eq(true)
+      end
+    end
   end
 
   describe '#patch' do


### PR DESCRIPTION
As of [Mailchimp 3.0](https://mailchimp.com/developer/reference/campaigns/#post_/campaigns/-campaign_id-/actions/send), sending a campaign will return a 204 No Content on success. 

The gem currently will return a `<MailchimpError status=204>`. The fix handles the 204 and returns a `true` response.

NOTE: Not sure what is up with CircleCI