### PR TITLE
feat: allow using a state parameter in the authorization flow

### DIFF
--- a/lib/mailchimp3/oauth.rb
+++ b/lib/mailchimp3/oauth.rb
@@ -13,8 +13,13 @@ module MailChimp3
       )
     end
 
-    def authorize_url(redirect_uri:)
-      @oauth.auth_code.authorize_url(redirect_uri: redirect_uri)
+    def authorize_url(redirect_uri:, state: nil)
+      params = {
+        redirect_uri: redirect_uri,
+        state: state,
+      }.compact
+
+      @oauth.auth_code.authorize_url(params)
     end
 
     def complete_auth(code, redirect_uri:)

--- a/spec/mailchimp3/oauth_spec.rb
+++ b/spec/mailchimp3/oauth_spec.rb
@@ -13,6 +13,14 @@ describe MailChimp3::OAuth do
       )
       expect(url).to eq('https://login.mailchimp.com/oauth2/authorize?client_id=foo&redirect_uri=http%3A%2F%2Fexample.com%2Foauth%2Fcallback&response_type=code')
     end
+
+    it 'passes through an optional state param' do
+      url = subject.authorize_url(
+        redirect_uri: 'http://example.com/oauth/callback',
+        state: "123456"
+      )
+      expect(url).to eq('https://login.mailchimp.com/oauth2/authorize?client_id=foo&redirect_uri=http%3A%2F%2Fexample.com%2Foauth%2Fcallback&response_type=code&state=123456')
+    end
   end
 
   describe '#complete_auth' do


### PR DESCRIPTION
I want to use the `state` param in the Mailchimp OAuth flow.