### PR TITLE
🧲 Loosen `faraday` dependency to 1.x

### DIFF
--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -131,7 +131,7 @@ module MailChimp3
     def _connection
       @connection ||= Faraday.new(url: url) do |faraday|
         if @basic_auth_key
-          faraday.basic_auth '', @basic_auth_key
+          faraday.request :basic_auth, '', @basic_auth_key
         elsif @oauth_access_token
           faraday.headers['Authorization'] = "Bearer #{@oauth_access_token}"
         else

--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -130,7 +130,6 @@ module MailChimp3
 
     def _connection
       @connection ||= Faraday.new(url: url) do |faraday|
-        faraday.adapter :excon
         if @basic_auth_key
           faraday.basic_auth '', @basic_auth_key
         elsif @oauth_access_token
@@ -138,6 +137,7 @@ module MailChimp3
         else
           fail Errors::AuthRequiredError, "You must specify either HTTP basic auth credentials or an OAuth2 access token."
         end
+        faraday.adapter :excon
       end
     end
   end

--- a/mailchimp3.gemspec
+++ b/mailchimp3.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "excon", ">= 0.71.0"
   s.add_dependency "oauth2", "~> 1.2"
   s.add_development_dependency "rspec", "~> 3.2"
-  s.add_development_dependency "webmock", "~> 1.21"
+  s.add_development_dependency "webmock", "< 4"
   s.add_development_dependency "pry", "~> 0.10"
 end

--- a/mailchimp3.gemspec
+++ b/mailchimp3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "faraday", "~> 0.9"
+  s.add_dependency "faraday", "< 2"
   s.add_dependency "excon", ">= 0.71.0"
   s.add_dependency "oauth2", "~> 1.2"
   s.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
The latest version is 1.8.0 and this allows it to be used.