### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![Circle CI](https://circleci.com/gh/seven1m/mailchimp3/tree/master.svg?style=svg)](https://circleci.com/gh/seven1m/mailchimp3/tree/master)
 
-`mailchimp3` is a Rubygem that provides a very thin, simple wrapper around the MailChimp RESTful JSON API version 3.0
-documented at [kb.mailchimp.com/api](http://kb.mailchimp.com/api/). (The wrapper also works with the 2.0 API if you
-just use the `post` method. See 2.0 section later in this document.)
+`mailchimp3` is a Rubygem that provides a very thin, simple wrapper around the MailChimp RESTful JSON "Marketing" API version 3
+documented at [mailchimp.com/developer/marketing/api](https://mailchimp.com/developer/marketing/api/).
 
 This wrapper is very low-level -- you'll still be dealing with individual GET, POST, PATCH, and DELETE requests, but the gem
 handles the OAuth2 flow (getting a token), passing the auth token in every request, and raises descriptive errors you can easily rescue
@@ -273,21 +272,6 @@ The `message` should be a simple string given by the API, e.g. "Resource Not Fou
 Alternatively, you may rescue `MailChimp3::Errors::BaseError` and branch your code based on
 the status code returned by calling `error.status`.
 
-## MailChimp 2.0 API
-
-This wrapper works with MailChimp's soon-to-be-deprecated 2.0 API. You need only use the `v2` path and the `post` method
-for all your calls, like so:
-
-```ruby
-api.v2.lists['member-activity'].post(id: 'abc123', emails: [{email: 'tim@timmorgan.org'}])
-```
-
-Some notes:
-
-1. Call `v2` to switch to the 2.0 API, then add other path elements after that.
-2. Any path element with a hyphen will need to use the array access syntax, e.g. `lists['member-activity']` not `lists.member-activity`.
-3. You must use the `post` method for every call.
-
 ## Copyright & License
 
-Copyright 2015, Tim Morgan. Licensed MIT.
+Copyright 2021, Planning Center. Licensed MIT.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MailChimp3
 
-[![Circle CI](https://circleci.com/gh/seven1m/mailchimp3/tree/master.svg?style=svg)](https://circleci.com/gh/seven1m/mailchimp3/tree/master)
+[![CircleCI](https://circleci.com/gh/planningcenter/mailchimp3/tree/master.svg?style=svg)](https://circleci.com/gh/planningcenter/mailchimp3/tree/master)
 
 `mailchimp3` is a Rubygem that provides a very thin, simple wrapper around the MailChimp RESTful JSON "Marketing" API version 3
 documented at [mailchimp.com/developer/marketing/api](https://mailchimp.com/developer/marketing/api/).

--- a/README.md
+++ b/README.md
@@ -184,7 +184,18 @@ api.lists.post(
 }
 ```
 
-## get()
+## method_missing(endpoint_name)
+
+Anything you append to the end gets handled by `method_missing` and returns a new Endpoint object.
+This is what allows this gem work with any endpoint without the library code needing to be updated.
+
+## \[](endpoint_name_or_id)
+
+Similar to the `method_missing` above, `endpoint['whatever']` and `endpoint[123]` are handled dynamically,
+which allows you to build endpoints containing numbers, hyphens, or other characters not allowed by a
+Ruby method name.
+
+## get(params = {})
 
 `get()` works for a collection (index) and a single resource (show).
 
@@ -198,7 +209,9 @@ api.lists['abc123'].members['cde345'].get
 # => resource_hash
 ```
 
-## post()
+If the endpoint accepts parameters, you can pass them in the `params` hash.
+
+## post(body = {})
 
 `post()` sends a POST request to create a new resource.
 
@@ -207,7 +220,9 @@ api.lists['abc123'].members.post(...)
 # => resource_hash
 ```
 
-## patch()
+The parameter given is sent as the body of the request. See [Example](#example) above.
+
+## patch(body = {})
 
 `patch()` sends a PATCH request to update an existing resource.
 
@@ -215,6 +230,8 @@ api.lists['abc123'].members.post(...)
 api.lists['abc123'].members['cde345'].patch(...)
 # => resource_hash
 ```
+
+The parameter given is sent as the body of the request. See [Example](#example) above.
 
 ## delete()
 

--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -16,12 +16,12 @@ module MailChimp3
       @cache = {}
     end
 
-    def method_missing(method_name, *_args)
-      _build_endpoint(method_name.to_s)
+    def method_missing(endpoint_name, *_args)
+      _build_endpoint(endpoint_name.to_s)
     end
 
-    def [](id)
-      _build_endpoint(id.to_s)
+    def [](endpoint_name_or_id)
+      _build_endpoint(endpoint_name_or_id.to_s)
     end
 
     def get(params = {})


### PR DESCRIPTION
I removed references to the old "v2" API, since it doesn't seem to be mentioned at all any more on the Mailchimp website.

I also took the opportunity to improve the documentation of the various endpoint methods.