### PR TITLE
📌 Pin `faraday` version to 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Chore: Pin `faraday` to >= 1
+
 # 1.5.1 (December 10, 2021)
 
 * Fix: Resolve faraday deprecation warning

--- a/mailchimp3.gemspec
+++ b/mailchimp3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "faraday", "< 2"
+  s.add_dependency "faraday", "~> 1.0"
   s.add_dependency "excon", ">= 0.71.0"
   s.add_dependency "oauth2", "~> 1.2"
   s.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
In [a previous PR]()https://github.com/planningcenter/mailchimp3/pull/11, where we loosed the `faraday` version requirement to allow for >= v1, [I made a change to resolve a deprecation warning](https://github.com/planningcenter/mailchimp3/pull/11/commits/8cc852884ec12193017fe324c106a969433ac02e). Unfortunately, that change is only valid in versions >= 1. We're going to go ahead and require that as well.