### PR TITLE
Fix bug creating error objects in Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/ruby:2.5
+    - image: circleci/ruby:3.0
     steps:
     - checkout
     - run: bundle

--- a/lib/mailchimp3/endpoint.rb
+++ b/lib/mailchimp3/endpoint.rb
@@ -81,23 +81,23 @@ module MailChimp3
       when 200..299
         body
       when 400
-        fail Errors::BadRequest, status: status, body: body
+        fail Errors::BadRequest.new(status: status, body: body)
       when 401
-        fail Errors::Unauthorized, status: status, body: body
+        fail Errors::Unauthorized.new(status: status, body: body)
       when 403
-        fail Errors::Forbidden, status: status, body: body
+        fail Errors::Forbidden.new(status: status, body: body)
       when 404
-        fail Errors::NotFound, status: status, body: body
+        fail Errors::NotFound.new(status: status, body: body)
       when 405
-        fail Errors::MethodNotAllowed, status: status, body: body
+        fail Errors::MethodNotAllowed.new(status: status, body: body)
       when 422
-        fail Errors::UnprocessableEntity, status: status, body: body
+        fail Errors::UnprocessableEntity.new(status: status, body: body)
       when 400..499
-        fail Errors::ClientError, status: status, body: body
+        fail Errors::ClientError.new(status: status, body: body)
       when 500
-        fail Errors::InternalServerError, status: status, body: body
+        fail Errors::InternalServerError.new(status: status, body: body)
       when 500..599
-        fail Errors::ServerError, status: status, body: body
+        fail Errors::ServerError.new(status: status, body: body)
       else
         fail "unknown status #{status}"
       end
@@ -106,7 +106,7 @@ module MailChimp3
     def _parse_body(result)
       JSON.parse(result.body)
     rescue JSON::ParserError
-      raise Errors::ServerError, status: result.status, body: result.body
+      raise Errors::ServerError.new(status: result.status, body: result.body)
     end
 
     def _build_endpoint(path)


### PR DESCRIPTION
This resolves the error:

    ArgumentError: wrong number of arguments
    (given 1, expected 0; required keywords: body, status)



This PR also makes it so we use Ruby 3.0 in CI.