### PR TITLE
chore(MailChimp3#new): forward keyword args in ruby 3.x compatible way

### DIFF
--- a/lib/mailchimp3.rb
+++ b/lib/mailchimp3.rb
@@ -5,8 +5,8 @@ require_relative 'mailchimp3/errors'
 module MailChimp3
   module_function
 
-  def new(*args)
-    Endpoint.new(*args)
+  def new(**kwargs)
+    Endpoint.new(**kwargs)
   end
 
   def config

--- a/spec/mailchimp3_spec.rb
+++ b/spec/mailchimp3_spec.rb
@@ -1,6 +1,12 @@
 require_relative 'spec_helper'
 
 describe MailChimp3 do
+  describe '#new' do
+    it 'smoke test' do
+      expect(subject.new(basic_auth_key: 'key-us2').url).not_to be_nil
+    end
+  end
+
   describe '#config' do
     it 'returns configuration object' do
       subject.config.client_id = 'foo'


### PR DESCRIPTION
In Ruby versions prior to 3, `*args` would forward along both positional and keyword arguments. In Ruby 3, `*args` _only_ forwards positional arguments. Because `Endpoint` only accepts keyword args, to maintain compatibility with Ruby 3, we need to switch to using a `**kwargs` argument here.

A simple smoke test has also been added for this method. The test failed before the change was made, and started passing after.

Reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/