### PR TITLE
Prepare release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.2 (April 4, 2023)
+
+* Fix: Forward keyword args to `MailChimp3#new` in Ruby 3.x compatible way (#17)
+
 # 1.5.1 (December 10, 2021)
 
 * Fix: Resolve faraday deprecation warning

--- a/lib/mailchimp3/version.rb
+++ b/lib/mailchimp3/version.rb
@@ -1,3 +1,3 @@
 module MailChimp3
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end


### PR DESCRIPTION
This updates the version number and changelog for version 1.5.2 of the gem (a fix for Ruby 3.x – see #17 for more info).

I'm requesting an additional review on this one from you @seven1m since you've published this gem before (both on GitHub and to RubyGems). If you have any thoughts here or other info on releasing this gem, let me know!