### PR TITLE
chore(CODEOWNERS): Transfer (partial) ownership to the identity team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planningcenter/people @planningcenter/giving
+* @planningcenter/people @planningcenter/identity


### PR DESCRIPTION
The Giving team has split into the Giving & Identity teams. The Giving team's responsibility should now shift to the Identity team. Let's make it so!